### PR TITLE
Fix findlib initialization

### DIFF
--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -721,7 +721,12 @@ let patch_env () =
   in ()
 
 let init ~verbose:v ~silent:s ~verbose_findlib () =
-  Findlib.init_manually ~install_dir:"" ~meta_dir:"" ~search_path:[] ();
+  let search_path =
+    match Sys.getenv "OCAMLPATH" with
+    | exception Not_found -> []
+    | p -> Fl_split.path p
+  in
+  Findlib.init_manually ~install_dir:"" ~meta_dir:"" ~search_path ();
   Clflags.real_paths := false;
   Toploop.set_paths ();
   Mdx.Compat.init_path ();

--- a/lib/top/mdx_top.ml
+++ b/lib/top/mdx_top.ml
@@ -721,6 +721,7 @@ let patch_env () =
   in ()
 
 let init ~verbose:v ~silent:s ~verbose_findlib () =
+  Findlib.init_manually ~install_dir:"" ~meta_dir:"" ~search_path:[] ();
   Clflags.real_paths := false;
   Toploop.set_paths ();
   Mdx.Compat.init_path ();


### PR DESCRIPTION
There was a bug in Findlib that prevented us from using it without config file, should be fixed in https://github.com/dune-universe/lib-findlib/pull/3.

We can now use `Findlib.init_manually` and the `findlib.conf` hack is no longer needed.